### PR TITLE
feat: extend Apprise notifications with Discord, Slack, and Generic Webhook support

### DIFF
--- a/src/lib/server/services/notify.ts
+++ b/src/lib/server/services/notify.ts
@@ -1,6 +1,7 @@
 /**
  * Notification sending — server-only.
  * Handles SMTP (via nodemailer) and Apprise URL schemes.
+ * Natively supports: Telegram, Discord, Slack, Generic Webhook (JSON/JSONS).
  */
 
 import type { AppriseConfig, SmtpConfig, ResolvedChannel } from '../queries';
@@ -11,6 +12,11 @@ const TEST_BODY = 'This is a test notification from AutoKube — your channel is
 /** Escape HTML special characters for Telegram HTML parse mode */
 function escapeHtml(text: string): string {
 	return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Escape Markdown special characters for Discord */
+function escapeMarkdown(text: string): string {
+	return text.replace(/([*_~`|\\])/g, '\\$1');
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -86,8 +92,20 @@ async function sendAppriseUrl(url: string, title: string, body: string): Promise
 		return sendTelegram(url, formatTelegramHtml(title, body));
 	}
 
+	if (lower.startsWith('discord://')) {
+		return sendDiscord(url, title, body);
+	}
+
+	if (lower.startsWith('slack://')) {
+		return sendSlack(url, title, body);
+	}
+
+	if (lower.startsWith('json://') || lower.startsWith('jsons://')) {
+		return sendGenericWebhook(url, title, body);
+	}
+
 	// Generic fallback: Apprise REST API
-	const appriseApiUrl = process.env.APPRISE_API_URL;
+	const appriseApiUrl = Bun.env.APPRISE_API_URL;
 	if (appriseApiUrl) {
 		const res = await fetch(`${appriseApiUrl}/notify`, {
 			method: 'POST',
@@ -165,5 +183,225 @@ async function sendTelegram(url: string, html: string): Promise<void> {
 		if (!data.ok) {
 			throw new Error(`Telegram API error: ${data.description ?? 'unknown error'}`);
 		}
+	}
+}
+
+// ── Discord ──────────────────────────────────────────────────────────────────
+
+/**
+ * Format title + body as a Discord embed.
+ * Parses "label: value" lines into embed fields for rich rendering.
+ */
+function formatDiscordEmbed(
+	title: string,
+	body: string
+): { title: string; description: string; color: number; fields: { name: string; value: string; inline: boolean }[]; footer: { text: string } } {
+	const lines = body.split('\n').filter(Boolean);
+	const fields: { name: string; value: string; inline: boolean }[] = [];
+	const descriptionLines: string[] = [];
+
+	for (const line of lines) {
+		// "emoji Label: value" → embed field
+		const labelMatch = line.match(/^(.+?):\s+(.+)$/u);
+		if (labelMatch) {
+			fields.push({
+				name: labelMatch[1].trim(),
+				value: escapeMarkdown(labelMatch[2].trim()),
+				inline: true
+			});
+			continue;
+		}
+		// 💬 message lines → description
+		const msgMatch = line.match(/^💬\s+(.+)$/u);
+		if (msgMatch) {
+			descriptionLines.push(`> _${escapeMarkdown(msgMatch[1])}_`);
+			continue;
+		}
+		descriptionLines.push(escapeMarkdown(line));
+	}
+
+	// Use orange for warning emojis, blue otherwise
+	const isWarning = title.includes('⚠️') || title.includes('🔴');
+	const color = isWarning ? 0xff6600 : 0x3498db;
+
+	return {
+		title,
+		description: descriptionLines.join('\n') || body,
+		color,
+		fields: fields.slice(0, 25), // Discord allows max 25 fields
+		footer: { text: 'autokube.io' }
+	};
+}
+
+/**
+ * Parse discord://WebhookID/WebhookToken and send via Discord Webhook API.
+ * URL format: discord://WebhookID/WebhookToken
+ */
+async function sendDiscord(url: string, title: string, body: string): Promise<void> {
+	const path = url.replace(/^discord:\/\//i, '');
+	const parts = path.split('/').filter(Boolean);
+	if (parts.length < 2) {
+		throw new Error(
+			'Invalid discord:// URL. Expected format: discord://WebhookID/WebhookToken'
+		);
+	}
+
+	const webhookId = parts[0];
+	const webhookToken = parts[1];
+	const embed = formatDiscordEmbed(title, body);
+
+	const res = await fetch(
+		`https://discord.com/api/webhooks/${webhookId}/${webhookToken}`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				username: 'AutoKube',
+				embeds: [embed]
+			})
+		}
+	);
+
+	if (!res.ok) {
+		const text = await res.text().catch(() => res.statusText);
+		throw new Error(`Discord Webhook error: ${res.status} ${text}`);
+	}
+}
+
+// ── Slack ────────────────────────────────────────────────────────────────────
+
+/**
+ * Format title + body into Slack Block Kit blocks for rich rendering.
+ */
+function formatSlackBlocks(
+	title: string,
+	body: string
+): { type: string; text?: { type: string; text: string }; elements?: { type: string; text: string }[]; fields?: { type: string; text: string }[] }[] {
+	const lines = body.split('\n').filter(Boolean);
+	const fields: { type: string; text: string }[] = [];
+	const contextLines: string[] = [];
+
+	for (const line of lines) {
+		// "emoji Label: value" → section field
+		const labelMatch = line.match(/^(.+?):\s+(.+)$/u);
+		if (labelMatch) {
+			fields.push({
+				type: 'mrkdwn',
+				text: `*${labelMatch[1].trim()}*\n${labelMatch[2].trim()}`
+			});
+			continue;
+		}
+		// 💬 message lines → context
+		const msgMatch = line.match(/^💬\s+(.+)$/u);
+		if (msgMatch) {
+			contextLines.push(`_${msgMatch[1]}_`);
+			continue;
+		}
+		contextLines.push(line);
+	}
+
+	const blocks: { type: string; text?: { type: string; text: string }; elements?: { type: string; text: string }[]; fields?: { type: string; text: string }[] }[] = [
+		{
+			type: 'header',
+			text: { type: 'plain_text', text: title }
+		}
+	];
+
+	// Add fields in groups of 10 (Slack limit per section)
+	for (let i = 0; i < fields.length; i += 10) {
+		blocks.push({
+			type: 'section',
+			fields: fields.slice(i, i + 10)
+		});
+	}
+
+	if (contextLines.length > 0) {
+		blocks.push({
+			type: 'context',
+			elements: [{ type: 'mrkdwn', text: contextLines.join('\n') }]
+		});
+	}
+
+	blocks.push({
+		type: 'context',
+		elements: [{ type: 'mrkdwn', text: 'autokube.io' }]
+	});
+
+	return blocks;
+}
+
+/**
+ * Parse slack://TokenA/TokenB/TokenC and send via Slack Incoming Webhook API.
+ * URL format: slack://TokenA/TokenB/TokenC
+ * Maps to: https://hooks.slack.com/services/TokenA/TokenB/TokenC
+ */
+async function sendSlack(url: string, title: string, body: string): Promise<void> {
+	const path = url.replace(/^slack:\/\//i, '');
+	const parts = path.split('/').filter(Boolean);
+	if (parts.length < 3) {
+		throw new Error(
+			'Invalid slack:// URL. Expected format: slack://TokenA/TokenB/TokenC'
+		);
+	}
+
+	const [tokenA, tokenB, tokenC] = parts;
+	const webhookUrl = `https://hooks.slack.com/services/${tokenA}/${tokenB}/${tokenC}`;
+	const blocks = formatSlackBlocks(title, body);
+
+	const res = await fetch(webhookUrl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			text: `${title}\n${body}`,
+			blocks
+		})
+	});
+
+	if (!res.ok) {
+		const text = await res.text().catch(() => res.statusText);
+		throw new Error(`Slack Webhook error: ${res.status} ${text}`);
+	}
+}
+
+// ── Generic Webhook (JSON) ───────────────────────────────────────────────────
+
+/**
+ * Parse json:// or jsons:// URL and POST a JSON payload.
+ * URL format: json://hostname[:port][/path]  (HTTP)
+ *             jsons://hostname[:port][/path] (HTTPS)
+ *
+ * Sends a structured JSON payload with title, body, and metadata.
+ */
+async function sendGenericWebhook(url: string, title: string, body: string): Promise<void> {
+	const isHttps = url.toLowerCase().startsWith('jsons://');
+	const protocol = isHttps ? 'https' : 'http';
+	// Strip the scheme and reconstruct as http(s)
+	const rest = url.replace(/^jsons?:\/\//i, '');
+
+	if (!rest) {
+		throw new Error(
+			'Invalid json:// URL. Expected format: json://hostname[:port][/path]'
+		);
+	}
+
+	const webhookUrl = `${protocol}://${rest}`;
+
+	const payload = {
+		title,
+		body,
+		message: `${title}\n\n${body}`,
+		source: 'autokube',
+		timestamp: new Date().toISOString()
+	};
+
+	const res = await fetch(webhookUrl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(payload)
+	});
+
+	if (!res.ok) {
+		const text = await res.text().catch(() => res.statusText);
+		throw new Error(`Webhook error: ${res.status} ${text}`);
 	}
 }

--- a/src/routes/(app)/settings/tabs/notifications-tab.svelte
+++ b/src/routes/(app)/settings/tabs/notifications-tab.svelte
@@ -20,7 +20,10 @@
 		CheckCircle2,
 		AlertCircle,
 		Loader2,
-		ChevronDown
+		ChevronDown,
+		MessageCircle,
+		Hash,
+		Webhook
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { NOTIFICATION_EVENT_TYPES } from '$lib/notifications-constants';
@@ -52,7 +55,8 @@
 		smtpFromName: 'AutoKube Alerts',
 		smtpTo: '',
 		// apprise
-		appriseUrl: ''
+		appriseUrl: '',
+		appriseScheme: 'tgram' as 'tgram' | 'discord' | 'slack' | 'json' | 'custom'
 	});
 
 	let errors = $state<Record<string, string>>({});
@@ -96,7 +100,8 @@
 			smtpFromAddress: '',
 			smtpFromName: 'AutoKube Alerts',
 			smtpTo: '',
-			appriseUrl: ''
+			appriseUrl: '',
+			appriseScheme: 'tgram'
 		};
 		errors = {};
 		testResult = '';
@@ -121,10 +126,12 @@
 				smtpFromAddress: String(cfg.from_email ?? ''),
 				smtpFromName: String(cfg.from_name ?? ''),
 				smtpTo: Array.isArray(cfg.to_emails) ? (cfg.to_emails as string[]).join(', ') : '',
-				appriseUrl: ''
+				appriseUrl: '',
+				appriseScheme: 'tgram'
 			};
 		} else {
 			const urls = Array.isArray(cfg.urls) ? (cfg.urls as string[]) : [];
+			const url = urls[0] ?? '';
 			form = {
 				name: ch.name,
 				enabled: ch.enabled,
@@ -138,13 +145,24 @@
 				smtpFromAddress: '',
 				smtpFromName: 'AutoKube Alerts',
 				smtpTo: '',
-				appriseUrl: urls[0] ?? ''
+				appriseUrl: url,
+				appriseScheme: detectScheme(url)
 			};
 		}
 		errors = {};
 		testResult = '';
 		testSuccess = null;
 		dialogOpen = true;
+	}
+
+	/** Detect Apprise scheme from URL for the sub-type selector. */
+	function detectScheme(url: string): 'tgram' | 'discord' | 'slack' | 'json' | 'custom' {
+		const lower = url.toLowerCase();
+		if (lower.startsWith('tgram://')) return 'tgram';
+		if (lower.startsWith('discord://')) return 'discord';
+		if (lower.startsWith('slack://')) return 'slack';
+		if (lower.startsWith('json://') || lower.startsWith('jsons://')) return 'json';
+		return 'custom';
 	}
 
 	function validate(): boolean {
@@ -255,13 +273,71 @@
 				return `${scheme}${visible}••••${rest ?? ''}`;
 			});
 		}
+		// discord://WebhookID/WebhookToken — mask the token
+		if (/^discord:\/\//i.test(url)) {
+			return url.replace(/(discord:\/\/[^/]+\/)(.+)$/i, (_, prefix, token) => {
+				return `${prefix}${token.slice(0, 4)}••••`;
+			});
+		}
+		// slack://TokenA/TokenB/TokenC — mask TokenB and TokenC
+		if (/^slack:\/\//i.test(url)) {
+			return url.replace(/(slack:\/\/[^/]+\/)(.+)$/i, (_, prefix) => {
+				return `${prefix}••••/••••`;
+			});
+		}
+		// json:// or jsons:// — show host, mask path
+		if (/^jsons?:\/\//i.test(url)) {
+			const match = url.match(/^(jsons?:\/\/[^/]+)(\/.*)?$/i);
+			if (match) return `${match[1]}${match[2] ? '/••••' : ''}`;
+		}
 		// Generic: mask user:pass@host style credentials
 		return url.replace(/(:\/\/[^:@]*:[^@]*)@/, '://••••@').replace(/(\/[^/]{4})[^/]+$/, '$1••••');
+	}
+
+	/** Get a friendly label for the Apprise URL scheme shown in the channel list. */
+	function channelSchemeLabel(url: string): string {
+		const lower = url.toLowerCase();
+		if (lower.startsWith('tgram://')) return 'Telegram';
+		if (lower.startsWith('discord://')) return 'Discord';
+		if (lower.startsWith('slack://')) return 'Slack';
+		if (lower.startsWith('json://') || lower.startsWith('jsons://')) return 'Webhook';
+		return 'Apprise';
 	}
 
 	function channelsForEvent(eventId: string): ResolvedChannel[] {
 		return channels.filter((ch) => ch.enabled && ch.eventTypes.includes(eventId as never));
 	}
+
+	// ── Apprise scheme helpers ─────────────────────────────────────────────
+	const appriseSchemeLabel = $derived(
+		({
+			tgram: 'Telegram Bot URL',
+			discord: 'Discord Webhook URL',
+			slack: 'Slack Webhook URL',
+			json: 'Webhook endpoint URL',
+			custom: 'Any Apprise URL'
+		})[form.appriseScheme]
+	);
+
+	const apprisePlaceholder = $derived(
+		({
+			tgram: 'tgram://BotToken/ChatID',
+			discord: 'discord://WebhookID/WebhookToken',
+			slack: 'slack://TokenA/TokenB/TokenC',
+			json: 'json://hostname:port/path  or  jsons://hostname/path',
+			custom: 'scheme://...'
+		})[form.appriseScheme]
+	);
+
+	const appriseHelpText = $derived(
+		({
+			tgram: 'Create a bot via @BotFather, then use tgram://BOT_TOKEN/CHAT_ID. Multiple chat IDs: tgram://TOKEN/ID1/ID2',
+			discord: 'Go to Server Settings → Integrations → Webhooks → Copy URL, then use discord://WEBHOOK_ID/WEBHOOK_TOKEN',
+			slack: 'Create an Incoming Webhook in your Slack app, then use slack://TOKEN_A/TOKEN_B/TOKEN_C from the webhook URL',
+			json: 'POST a JSON payload to any HTTP endpoint. Use json:// for HTTP, jsons:// for HTTPS',
+			custom: 'Any Apprise-compatible URL. Requires APPRISE_API_URL env var for unsupported schemes.'
+		})[form.appriseScheme]
+	);
 
 	/** Check if a specific channel is subscribed to an event (regardless of enabled state) */
 	function isChannelSubscribed(channelId: number, eventId: string): boolean {
@@ -358,7 +434,17 @@
 				<!-- Icon -->
 				<div class="flex size-9 shrink-0 items-center justify-center rounded-full border bg-muted">
 					{#if ch.type === 'apprise'}
-						<Zap class="size-4 text-yellow-500" />
+						{@const urls = (ch.config as unknown as { urls?: string[] }).urls ?? []}
+						{@const scheme = urls[0]?.toLowerCase() ?? ''}
+						{#if scheme.startsWith('discord://')}
+							<MessageCircle class="size-4 text-indigo-500" />
+						{:else if scheme.startsWith('slack://')}
+							<Hash class="size-4 text-green-500" />
+						{:else if scheme.startsWith('json://') || scheme.startsWith('jsons://')}
+							<Webhook class="size-4 text-orange-500" />
+						{:else}
+							<Zap class="size-4 text-yellow-500" />
+						{/if}
 					{:else}
 						<Mail class="size-4 text-blue-500" />
 					{/if}
@@ -369,7 +455,12 @@
 					<div class="flex flex-wrap items-center gap-1.5">
 						<span class="text-sm font-medium">{ch.name}</span>
 						<Badge variant="secondary" class="font-mono text-[10px] capitalize">
-							{ch.type === 'apprise' ? 'Apprise' : 'SMTP'}
+							{#if ch.type === 'apprise'}
+								{@const urls = (ch.config as unknown as { urls?: string[] }).urls ?? []}
+								{channelSchemeLabel(urls[0] ?? '')}
+							{:else}
+								SMTP
+							{/if}
 						</Badge>
 						{#if ch.enabled}
 							<Badge variant="outline" class="text-[10px]">
@@ -653,23 +744,65 @@
 			{:else}
 				<!-- Apprise Fields -->
 				<div class="space-y-1.5">
+					<Label>Service</Label>
+					<div class="grid grid-cols-5 gap-1.5">
+						<button
+							type="button"
+							class="flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs transition-colors hover:bg-muted/60 {form.appriseScheme === 'tgram' ? 'border-primary bg-primary/5 text-primary' : 'text-muted-foreground'}"
+							onclick={() => (form.appriseScheme = 'tgram')}
+						>
+							<Send class="size-4" />
+							Telegram
+						</button>
+						<button
+							type="button"
+							class="flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs transition-colors hover:bg-muted/60 {form.appriseScheme === 'discord' ? 'border-primary bg-primary/5 text-primary' : 'text-muted-foreground'}"
+							onclick={() => (form.appriseScheme = 'discord')}
+						>
+							<MessageCircle class="size-4" />
+							Discord
+						</button>
+						<button
+							type="button"
+							class="flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs transition-colors hover:bg-muted/60 {form.appriseScheme === 'slack' ? 'border-primary bg-primary/5 text-primary' : 'text-muted-foreground'}"
+							onclick={() => (form.appriseScheme = 'slack')}
+						>
+							<Hash class="size-4" />
+							Slack
+						</button>
+						<button
+							type="button"
+							class="flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs transition-colors hover:bg-muted/60 {form.appriseScheme === 'json' ? 'border-primary bg-primary/5 text-primary' : 'text-muted-foreground'}"
+							onclick={() => (form.appriseScheme = 'json')}
+						>
+							<Webhook class="size-4" />
+							Webhook
+						</button>
+						<button
+							type="button"
+							class="flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs transition-colors hover:bg-muted/60 {form.appriseScheme === 'custom' ? 'border-primary bg-primary/5 text-primary' : 'text-muted-foreground'}"
+							onclick={() => (form.appriseScheme = 'custom')}
+						>
+							<Zap class="size-4" />
+							Custom
+						</button>
+					</div>
+				</div>
+
+				<div class="space-y-1.5">
 					<Label for="apprise-url"
-						>Apprise URL <span class="text-xs text-muted-foreground">Notification service URL</span
+						>Apprise URL <span class="text-xs text-muted-foreground">{appriseSchemeLabel}</span
 						></Label
 					>
 					<Input
 						id="apprise-url"
-						placeholder="tgram://bottoken/chatid"
+						placeholder={apprisePlaceholder}
 						bind:value={form.appriseUrl}
 						class={errors.appriseUrl ? 'border-destructive' : ''}
 					/>
 					{#if errors.appriseUrl}<p class="text-xs text-destructive">{errors.appriseUrl}</p>{/if}
 					<p class="text-xs text-muted-foreground">
-						Supports Telegram, Slack, Discord, and 80+ more via <a
-							href="https://github.com/caronc/apprise"
-							target="_blank"
-							class="underline">Apprise</a
-						>
+						{appriseHelpText}
 					</p>
 				</div>
 			{/if}


### PR DESCRIPTION
- Add native Discord webhook sending with rich embeds (color-coded, fields, footer)
- Add native Slack sending via Block Kit (header, section fields, context)
- Add Generic Webhook (json:// / jsons://) sending with structured JSON payload
- Update UI with service sub-type selector (Telegram, Discord, Slack, Webhook, Custom)
- Add per-scheme placeholder URLs and help text in the channel dialog
- Update channel list icons: Discord (purple), Slack (green), Webhook (orange)
- Add URL masking for all new schemes in channel summary display
- Detect scheme from URL when editing existing channels.