### PR TITLE
fix: only spin restart icon on the clicked row, not all rows

### DIFF
--- a/src/routes/(app)/daemonsets/+page.svelte
+++ b/src/routes/(app)/daemonsets/+page.svelte
@@ -57,7 +57,7 @@
 	let showDetailDialog = $state(false);
 	let selectedDaemonSet = $state<DaemonSetWithAge | null>(null);
 	let deleting = $state(false);
-	let restarting = $state(false);
+	let restartingKey = $state<string | null>(null);
 
 	// YAML editor
 	let showYamlDialog = $state(false);
@@ -229,7 +229,7 @@
 		if (!activeCluster?.id) return;
 
 		try {
-			restarting = true;
+			restartingKey = `${name}/${namespace}`;
 			const response = await fetch('/api/daemonsets/restart', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -247,7 +247,7 @@
 		} catch (err: any) {
 			toast.error(`Failed to restart daemonset: ${err.message}`);
 		} finally {
-			restarting = false;
+			restartingKey = null;
 		}
 	}
 
@@ -420,14 +420,14 @@
 								variant="ghost"
 								size="icon"
 								class="h-6 w-6 text-muted-foreground hover:cursor-pointer"
-								disabled={restarting}
+								disabled={restartingKey === `${daemonset.name}/${daemonset.namespace}`}
 								onclick={(e) => {
 									e.stopPropagation();
 									handleRestart(daemonset.name, daemonset.namespace);
 								}}
 								title="Restart"
 							>
-								<RotateCw class={cn('h-3.5 w-3.5', restarting && 'animate-spin')} />
+								<RotateCw class={cn('h-3.5 w-3.5', restartingKey === `${daemonset.name}/${daemonset.namespace}` && 'animate-spin')} />
 							</Button>
 							<Button
 								variant="ghost"

--- a/src/routes/(app)/deployments/+page.svelte
+++ b/src/routes/(app)/deployments/+page.svelte
@@ -60,7 +60,7 @@
 	let selectedDeployment = $state<DeploymentWithAge | null>(null);
 	let deleting = $state(false);
 	let scaling = $state(false);
-	let restarting = $state(false);
+	let restartingKey = $state<string | null>(null);
 
 	// Scale dialog
 	let showScaleDialog = $state(false);
@@ -251,7 +251,7 @@
 		if (!activeCluster?.id) return;
 
 		try {
-			restarting = true;
+			restartingKey = `${name}/${namespace}`;
 			const response = await fetch('/api/deployments/restart', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -269,7 +269,7 @@
 		} catch (err: any) {
 			toast.error(`Failed to restart deployment: ${err.message}`);
 		} finally {
-			restarting = false;
+			restartingKey = null;
 		}
 	}
 
@@ -458,14 +458,14 @@
 								variant="ghost"
 								size="icon"
 								class="h-6 w-6 text-muted-foreground hover:cursor-pointer"
-								disabled={restarting}
+								disabled={restartingKey === `${deployment.name}/${deployment.namespace}`}
 								onclick={(e) => {
 									e.stopPropagation();
 									handleRestart(deployment.name, deployment.namespace);
 								}}
 								title="Restart"
 							>
-								<RotateCw class={cn('h-3.5 w-3.5', restarting && 'animate-spin')} />
+								<RotateCw class={cn('h-3.5 w-3.5', restartingKey === `${deployment.name}/${deployment.namespace}` && 'animate-spin')} />
 							</Button>
 							<Button
 								variant="ghost"

--- a/src/routes/(app)/replicasets/+page.svelte
+++ b/src/routes/(app)/replicasets/+page.svelte
@@ -60,7 +60,7 @@
 	let selectedReplicaSet = $state<ReplicaSetWithAge | null>(null);
 	let deleting = $state(false);
 	let scaling = $state(false);
-	let restarting = $state(false);
+	let restartingKey = $state<string | null>(null);
 
 	// Scale dialog
 	let showScaleDialog = $state(false);
@@ -263,7 +263,7 @@
 		if (!activeCluster?.id) return;
 
 		try {
-			restarting = true;
+			restartingKey = `${name}/${namespace}`;
 			const response = await fetch('/api/replicasets/restart', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -281,7 +281,7 @@
 		} catch (err: any) {
 			toast.error(`Failed to restart replicaset: ${err.message}`);
 		} finally {
-			restarting = false;
+			restartingKey = null;
 		}
 	}
 
@@ -450,14 +450,14 @@
 								variant="ghost"
 								size="icon"
 								class="h-6 w-6 text-muted-foreground hover:cursor-pointer"
-								disabled={restarting}
+								disabled={restartingKey === `${replicaset.name}/${replicaset.namespace}`}
 								onclick={(e) => {
 									e.stopPropagation();
 									handleRestart(replicaset.name, replicaset.namespace);
 								}}
 								title="Restart"
 							>
-								<RotateCw class={cn('h-3.5 w-3.5', restarting && 'animate-spin')} />
+								<RotateCw class={cn('h-3.5 w-3.5', restartingKey === `${replicaset.name}/${replicaset.namespace}` && 'animate-spin')} />
 							</Button>
 							<Button
 								variant="ghost"

--- a/src/routes/(app)/statefulsets/+page.svelte
+++ b/src/routes/(app)/statefulsets/+page.svelte
@@ -60,7 +60,7 @@
 	let selectedStatefulSet = $state<StatefulSetWithAge | null>(null);
 	let deleting = $state(false);
 	let scaling = $state(false);
-	let restarting = $state(false);
+	let restartingKey = $state<string | null>(null);
 
 	// Scale dialog
 	let showScaleDialog = $state(false);
@@ -251,7 +251,7 @@
 		if (!activeCluster?.id) return;
 
 		try {
-			restarting = true;
+			restartingKey = `${name}/${namespace}`;
 			const response = await fetch('/api/statefulsets/restart', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -269,7 +269,7 @@
 		} catch (err: any) {
 			toast.error(`Failed to restart statefulset: ${err.message}`);
 		} finally {
-			restarting = false;
+			restartingKey = null;
 		}
 	}
 
@@ -442,14 +442,14 @@
 								variant="ghost"
 								size="icon"
 								class="h-6 w-6 text-muted-foreground hover:cursor-pointer"
-								disabled={restarting}
+								disabled={restartingKey === `${statefulset.name}/${statefulset.namespace}`}
 								onclick={(e) => {
 									e.stopPropagation();
 									handleRestart(statefulset.name, statefulset.namespace);
 								}}
 								title="Restart"
 							>
-								<RotateCw class={cn('h-3.5 w-3.5', restarting && 'animate-spin')} />
+								<RotateCw class={cn('h-3.5 w-3.5', restartingKey === `${statefulset.name}/${statefulset.namespace}` && 'animate-spin')} />
 							</Button>
 							<Button
 								variant="ghost"


### PR DESCRIPTION
## Summary

- Clicking the restart button on a Deployment, DaemonSet, StatefulSet, or ReplicaSet row was causing **all** restart icons in the table to spin simultaneously
- Root cause: `restarting` was a single shared boolean — setting it `true` affected every row's icon render

## Fix

Replaced `let restarting = $state(false)` with `let restartingKey = $state<string | null>(null)` in all four pages. The key is set to `name/namespace` while a restart is in flight, so each row independently checks whether *its own* key is active.

## Affected pages

- Deployments
- DaemonSets
- StatefulSets
- ReplicaSets

## Test plan

- [x] Click restart on one deployment — only that row's icon spins
- [x] Other rows remain static while the restart is in flight
- [x] Icon stops spinning after the request completes (success or error)
- [x] Same behaviour confirmed on DaemonSets, StatefulSets, ReplicaSets