### PR TITLE
ci: auto-create draft GitHub release on tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,3 +109,67 @@ jobs:
           git add charts/autokube/Chart.yaml charts/autokube/values.yaml
           git diff --staged --quiet && echo "No changes" || \
             (git commit -m "chore: bump autokube to ${{ needs.docker.outputs.version }}" && git push)
+
+  # ── Create draft GitHub Release with auto-generated changelog ─────────────
+  release:
+    name: Create Draft Release
+    runs-on: ubuntu-latest
+    needs: docker
+    # Only on tag push, not on workflow_dispatch (which has no tag)
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags for changelog
+
+      - name: Build release notes
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+
+          # Most recent semver tag that isn't the one being released
+          PREV_TAG=$(git tag --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${VERSION}$" \
+            | head -n1 || true)
+
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s" --no-merges)
+            COMPARE_LINK="**Full diff:** https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${VERSION}"
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s" --no-merges)
+            COMPARE_LINK=""
+          fi
+
+          {
+            echo "${VERSION} — <!-- TODO: headline -->"
+            echo ""
+            echo "<!-- TODO: 1-2 sentence intro describing the theme of this release -->"
+            echo ""
+            echo "## ✨ Highlights"
+            echo ""
+            echo "<!-- TODO: Group the major themes from the changelog below into bold-titled sections -->"
+            echo ""
+            echo "## 🔧 Upgrade notes"
+            echo ""
+            echo "<!-- TODO: Migration steps, breaking changes, backwards-compat notes. Delete this section if there's nothing to flag. -->"
+            echo ""
+            echo "## 📝 Full changelog"
+            echo ""
+            echo "${CHANGELOG}"
+            if [ -n "${COMPARE_LINK}" ]; then
+              echo ""
+              echo "${COMPARE_LINK}"
+            fi
+          } > /tmp/release-notes.md
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${{ github.repository }}" \
+            --title "${GITHUB_REF_NAME}" \
+            --draft \
+            --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

Adds a `release` job to `.github/workflows/docker-publish.yml` that runs **after** the Docker image is built and pushed. On tag push matching `v*.*.*`, it auto-creates a **draft** GitHub release with:

- Title set to the tag (e.g. `v1.4.0`)
- Auto-generated commit list (since the previous semver tag) under `## 📝 Full changelog`
- Placeholder `<!-- TODO -->` sections for headline, highlights, and upgrade notes — matching the v1.3.0 template format
- A "Full diff" compare link to the previous tag

The release is created as a **draft** because the v1.3.0-style highlights and upgrade notes are hand-written prose that can't be derived from commits. The intended flow:

1. Merge PR(s) into `main`
2. `git tag vX.Y.Z && git push origin vX.Y.Z`
3. CI: `docker` job builds + pushes the image
4. CI: `release` job creates the draft release with auto-generated changelog
5. Edit the draft, fill in headline / highlights / upgrade notes, click **Publish**

Skipped on `workflow_dispatch` since there's no tag to release.

## Test plan

- [ ] Merge this PR.
- [ ] On the next tag push, verify a draft release appears in the Releases page with the auto-generated changelog and TODO placeholders.
- [ ] Verify the Docker image is still built and pushed (existing `docker` job behavior unchanged).
- [ ] Verify `update-chart` still runs (existing behavior unchanged).
- [ ] Run `workflow_dispatch` and confirm the `release` job is **skipped** (only `docker` + `update-chart` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)