### PR TITLE
fix(watch): stop reconnect loop on missing CRD / unauthorized resource

### DIFF
--- a/src/lib/server/services/kubernetes/watch.ts
+++ b/src/lib/server/services/kubernetes/watch.ts
@@ -31,6 +31,55 @@ interface ListResponse {
 	items?: any[];
 }
 
+/**
+ * Drain the rest of an HTTP response body and resolve with it as a string.
+ * Used to read the K8s `Status` payload returned for non-2xx responses.
+ */
+function drainResponse(res: import('node:http').IncomingMessage): Promise<string> {
+	return new Promise((resolve) => {
+		const chunks: Buffer[] = [];
+		res.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+		res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+		res.on('error', () => resolve(Buffer.concat(chunks).toString('utf8')));
+	});
+}
+
+/**
+ * Map an HTTP status from a watch response to a stable error code that the
+ * SSE wrapper can use to decide whether to retry or give up.
+ */
+function watchErrorCodeForStatus(status: number): string {
+	if (status === 404) return 'NOT_FOUND';
+	if (status === 401 || status === 403) return 'UNAUTHORIZED';
+	if (status >= 500) return 'SERVER_ERROR';
+	return `HTTP_${status}`;
+}
+
+/**
+ * Build a rejected error from a non-2xx watch response. Reads the K8s
+ * `Status` object out of the body so we can include the API-server message
+ * (e.g. "the server could not find the requested resource") alongside our
+ * own code.
+ */
+async function buildHttpError(
+	res: import('node:http').IncomingMessage
+): Promise<NodeJS.ErrnoException> {
+	const status = res.statusCode ?? 0;
+	const body = await drainResponse(res);
+
+	let message = `HTTP ${status}`;
+	try {
+		const parsed = JSON.parse(body) as { message?: string };
+		if (parsed?.message) message = parsed.message;
+	} catch {
+		// Not JSON — keep the generic HTTP message.
+	}
+
+	const err = new Error(message) as NodeJS.ErrnoException;
+	err.code = watchErrorCodeForStatus(status);
+	return err;
+}
+
 interface SnapshotEntry {
 	object: any;
 	version: string;
@@ -39,7 +88,14 @@ interface SnapshotEntry {
 const AGENT_WATCH_POLL_INTERVAL = 3000;
 
 // Re-export resource path utilities for convenience
-export { buildWatchPath, getWatchPath, buildApiPath, buildListApiPath, getResourceConfig, RESOURCE_CONFIGS } from './resource-paths';
+export {
+	buildWatchPath,
+	getWatchPath,
+	buildApiPath,
+	buildListApiPath,
+	getResourceConfig,
+	RESOURCE_CONFIGS
+} from './resource-paths';
 
 function stripWatchParams(resourcePath: string): string {
 	const url = new URL(resourcePath, 'https://autokube.local');
@@ -211,6 +267,12 @@ export async function watchResource(
 
 		return new Promise((resolve, reject) => {
 			const req = https.request(options, (res) => {
+				const status = res.statusCode ?? 0;
+				if (status < 200 || status >= 300) {
+					buildHttpError(res).then(reject, reject);
+					return;
+				}
+
 				let buffer = '';
 
 				res.on('data', (chunk) => {
@@ -235,7 +297,13 @@ export async function watchResource(
 				});
 
 				res.on('error', (err: any) => {
-					const silent = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'FailedToOpenSocket'];
+					const silent = [
+						'ECONNRESET',
+						'ECONNREFUSED',
+						'ETIMEDOUT',
+						'ENOTFOUND',
+						'FailedToOpenSocket'
+					];
 					if (!silent.includes(err?.code)) {
 						console.error('[Watch Resource] Response error:', err);
 					}
@@ -244,7 +312,13 @@ export async function watchResource(
 			});
 
 			req.on('error', (err: any) => {
-				const silent = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'FailedToOpenSocket'];
+				const silent = [
+					'ECONNRESET',
+					'ECONNREFUSED',
+					'ETIMEDOUT',
+					'ENOTFOUND',
+					'FailedToOpenSocket'
+				];
 				if (!silent.includes(err?.code)) {
 					console.error('[Watch Resource] Request error:', err);
 				}
@@ -304,8 +378,7 @@ export async function watchResourceByCluster(
 		const url = `${config.server}${resourcePath}`;
 		const urlObj = new URL(url);
 
-		const skipTLS =
-			config.skipTLSVerify || process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
+		const skipTLS = config.skipTLSVerify || process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
 
 		const options: https.RequestOptions = {
 			hostname: urlObj.hostname,
@@ -336,6 +409,12 @@ export async function watchResourceByCluster(
 
 		return new Promise((resolve, reject) => {
 			const req = https.request(options, (res) => {
+				const status = res.statusCode ?? 0;
+				if (status < 200 || status >= 300) {
+					buildHttpError(res).then(reject, reject);
+					return;
+				}
+
 				let buffer = '';
 
 				res.on('data', (chunk) => {
@@ -360,7 +439,13 @@ export async function watchResourceByCluster(
 				});
 
 				res.on('error', (err: any) => {
-					const silent = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'FailedToOpenSocket'];
+					const silent = [
+						'ECONNRESET',
+						'ECONNREFUSED',
+						'ETIMEDOUT',
+						'ENOTFOUND',
+						'FailedToOpenSocket'
+					];
 					if (!silent.includes(err?.code)) {
 						console.error('[Watch Resource] Response error:', err);
 					}
@@ -369,7 +454,13 @@ export async function watchResourceByCluster(
 			});
 
 			req.on('error', (err: any) => {
-				const silent = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'FailedToOpenSocket'];
+				const silent = [
+					'ECONNRESET',
+					'ECONNREFUSED',
+					'ETIMEDOUT',
+					'ENOTFOUND',
+					'FailedToOpenSocket'
+				];
 				if (!silent.includes(err?.code)) {
 					console.error('[Watch Resource] Request error:', err);
 				}
@@ -391,4 +482,3 @@ export async function watchResourceByCluster(
 		throw error;
 	}
 }
-

--- a/src/routes/api/watch/[clusterId]/[resource]/+server.ts
+++ b/src/routes/api/watch/[clusterId]/[resource]/+server.ts
@@ -499,6 +499,21 @@ export const GET: RequestHandler = async ({ params, url, request, cookies }) => 
 					if (isAbort) {
 						// Normal client disconnect — exit loop silently
 						break;
+					} else if (code === 'NOT_FOUND') {
+						// Resource type does not exist on this cluster (e.g. CRD not installed).
+						// No point retrying — tell the client and exit so the page can show
+						// its "API not installed" empty state without a reconnect spam loop.
+						console.warn(
+							`[SSE] Resource not found for ${resource} (cluster ${clusterLabel}): ${msg}`
+						);
+						send({ type: 'ERROR', code: 'NOT_FOUND', error: msg });
+						break;
+					} else if (code === 'UNAUTHORIZED') {
+						// 401/403 — caller lacks permission to watch this resource.
+						// Won't self-heal without RBAC change; stop reconnecting.
+						console.warn(`[SSE] Unauthorized for ${resource} (cluster ${clusterLabel}): ${msg}`);
+						send({ type: 'ERROR', code: 'UNAUTHORIZED', error: msg });
+						break;
 					} else if (isConfigError) {
 						// Permanent config error — tell client to stop retrying, then exit
 						console.warn(`[SSE] Config error for ${resource} (cluster ${clusterLabel}): ${msg}`);


### PR DESCRIPTION
## Summary

Fixes the JSON-parse error loop you hit when opening the new Gateway pages on a cluster that doesn't have Gateway API CRDs installed:

\`\`\`
[SSE] Reconnecting watch for gateways (cluster "production" (#2), attempt 7)
[Watch Resource] Failed to parse event: SyntaxError: JSON Parse error...
\`\`\`

### Root cause

\`watch.ts\` (both \`watchResource\` and \`watchResourceByCluster\`) never inspected \`res.statusCode\`. When the K8s API returned **404** (CRD missing) or **401/403** (RBAC denied), the response body was a single JSON \`Status\` object — not the newline-delimited event stream the parser expected. Each chunk failed \`JSON.parse\`, the response then ended "normally", and the SSE wrapper in \`/api/watch/[clusterId]/[resource]/+server.ts\` reconnected after 500 ms — looping forever, spamming the logs with stack traces, and hammering the API server.

### Fix

1. **\`watch.ts\`** — check \`res.statusCode\` at the top of the response handler. On non-2xx, drain the body, parse the K8s \`Status\` message, and reject with a stable code:
   - 404 → \`NOT_FOUND\`
   - 401 / 403 → \`UNAUTHORIZED\`
   - 5xx → \`SERVER_ERROR\`
   - other → \`HTTP_<status>\`
2. **\`/api/watch/[clusterId]/[resource]/+server.ts\`** — treat \`NOT_FOUND\` and \`UNAUTHORIZED\` as terminal (mirror of the existing \`CONFIG_ERROR\` branch): send a final \`ERROR\` event with the code, then \`break\` out of the reconnect loop.

### Why this also matters beyond Gateway API

Same bug would have triggered for any K8s resource the caller can't see — e.g. an Operator-license user landing on \`/clusterroles\` without the right RBAC, or any cluster that legitimately doesn't have an optional API group installed. The fix is general.

## Test plan

- [ ] On a cluster **without** Gateway API CRDs, open \`/gateways\` — verify the empty state renders, server logs show **one** \`[SSE] Resource not found\` warning, and no reconnect loop / no \`Failed to parse event\` stack traces.
- [ ] On a cluster **with** Gateway API CRDs, verify watches still work (live updates on apply/delete).
- [ ] Scope a non-admin user away from \`pods\` via RBAC, navigate to \`/pods\` — verify the watch exits with \`UNAUTHORIZED\` instead of reconnecting.
- [ ] Stop the cluster's API server briefly and confirm \`CLUSTER_UNREACHABLE\` reconnect path still works (this branch is unchanged).
- [ ] \`bun run check\` — no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)